### PR TITLE
Fix log_execution_stats NameError in core module

### DIFF
--- a/smooth_criminal/core.py
+++ b/smooth_criminal/core.py
@@ -29,6 +29,7 @@ from typing import (
 )
 
 from smooth_criminal import memory
+from smooth_criminal.memory import log_execution_stats
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("SmoothCriminal")


### PR DESCRIPTION
## Summary
- Import `log_execution_stats` in `core.py` to ensure decorators can log execution stats without `NameError`.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdcb685a6c8327850694b245136bbb