### PR TITLE
Add randomized MJ mode decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 | `@black_or_white(mode)` | Optimiza tipos numéricos (`float32` vs `float64`)     |
 | `@bad`                  | Modo de optimización agresiva (`fastmath`)            |
 | `@beat_it`              | Fallback automático si algo falla                     |
+| `@mj_mode`              | Aplica un decorador aleatorio con mensaje de MJ       |
 | `dangerous(func)`       | Mezcla poderosa de decoradores (`@bad + @thriller`)   |
 | `@bad_and_dangerous`    | Optimiza, perfila y maneja errores automáticamente    |
 | `profile_it(func)`      | Estadísticas detalladas de rendimiento                |
@@ -157,6 +158,29 @@ print(data["fastest"])            # backend más veloz
 best = detect_fastest_backend(cube, [1, 2, 3], ["thread", "process", "async"])
 print(best)
 ```
+
+### 🎲 Decorador aleatorio `mj_mode`
+
+```python
+import random
+from smooth_criminal import mj_mode
+
+random.seed(0)
+
+@mj_mode
+def identidad(x):
+    return x
+
+print(identidad([1, 2, 3]))
+# Posible salida: "🥁 Jam session with 4 workers!"
+```
+
+Mensajes posibles:
+
+- 🕺 Hee-Hee! You're now smooth.
+- 😎 Who's bad? You're bad!
+- 🎬 It's Thriller time!
+- 🥁 Jam session with 4 workers!
 
 ## 🚧 Modo bad_and_dangerous
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,6 +4,24 @@ API
 .. automodule:: smooth_criminal.core
    :members:
 
+Ejemplo ``mj_mode``
+-------------------
+
+El decorador :func:`smooth_criminal.core.mj_mode` elige aleatoriamente uno de
+los otros decoradores y muestra un mensaje inspirado en Michael Jackson.
+
+.. code-block:: python
+
+   >>> import random, logging
+   >>> from smooth_criminal import mj_mode
+   >>> logging.getLogger("SmoothCriminal").setLevel(logging.CRITICAL)
+   >>> random.seed(0)
+   >>> @mj_mode
+   ... def identidad(x):
+   ...     return x
+   >>> identidad([1, 2])
+   [1, 2]  # Posible salida: "🥁 Jam session with 4 workers!"
+
 .. automodule:: smooth_criminal.benchmark
    :members:
 

--- a/smooth_criminal/__init__.py
+++ b/smooth_criminal/__init__.py
@@ -15,6 +15,7 @@ from .core import (
     dangerous,
     bad_and_dangerous,
     profile_it,
+    mj_mode,
 )
 
 from .benchmark import benchmark_jam, detect_fastest_backend
@@ -32,6 +33,7 @@ __all__ = [
     "dangerous",
     "bad_and_dangerous",
     "profile_it",
+    "mj_mode",
     "benchmark_jam",
     "detect_fastest_backend",
     "__version__",

--- a/smooth_criminal/core.py
+++ b/smooth_criminal/core.py
@@ -4,6 +4,7 @@ import inspect
 import ast
 import sys
 import os
+import random
 
 from numba import jit, vectorize as nb_vectorize, guvectorize as nb_guvectorize
 import numpy as np
@@ -99,6 +100,21 @@ def play_mj_effect(improvement: float, mj_mode: bool | None = None, *, threshold
 T = TypeVar("T")
 A = TypeVar("A")
 P = ParamSpec("P")
+
+
+def mj_mode(func: Callable[P, T]) -> Callable[P, T]:
+    """Aplica al azar un decorador icónico de MJ y muestra un mensaje."""
+
+    options = [
+        (smooth, "🕺 Hee-Hee! You're now smooth."),
+        (bad(), "😎 Who's bad? You're bad!"),
+        (thriller, "🎬 It's Thriller time!"),
+        (jam(workers=4), "🥁 Jam session with 4 workers!"),
+    ]
+
+    decorator, message = random.choice(options)
+    logger.info(message)
+    return decorator(func)
 
 
 def _process_worker(module_name: str, func_name: str, q) -> List[T]:

--- a/tests/test_mj_mode.py
+++ b/tests/test_mj_mode.py
@@ -1,0 +1,26 @@
+import random
+import logging
+
+from smooth_criminal import mj_mode
+
+
+def test_mj_mode_determinism(caplog):
+    random.seed(0)
+    caplog.set_level(logging.INFO, logger="SmoothCriminal")
+
+    @mj_mode
+    def identidad(x):
+        return x
+
+    assert identidad([1, 2]) == [1, 2]
+    assert "Jam session" in caplog.text
+
+    caplog.clear()
+    random.seed(2)
+
+    @mj_mode
+    def identidad2(x):
+        return x
+
+    assert identidad2([1, 2]) == [1, 2]
+    assert "smooth" in caplog.text


### PR DESCRIPTION
## Summary
- add `mj_mode` decorator to randomly wrap functions with MJ-themed decorators
- expose `mj_mode` publicly and document usage with examples
- cover `mj_mode` with deterministic tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdce1b6f388327a200cb68ef1b9426