### PR TITLE
docs: ampliar changelog e integrar guías de contribución

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,34 @@
 
 Todas las novedades y cambios notables de este proyecto.
 
+## [0.6.0] - En desarrollo
+
 ## [0.5.0] - 2024-08-09
 ### Añadido
 - Nuevas animaciones en el dashboard para celebrar mejoras de rendimiento.
 - Bandera `--mj-mode` en la CLI para activar efectos especiales de Michael Jackson.
 - API pública para consultar y manipular estadísticas desde otros procesos.
 - Plugin para editores que facilita el uso de Smooth Criminal directamente desde el IDE.
+
+## [0.4.0] - 2024-06-15
+### Añadido
+- Subcomando `jam-test` con opción `--silent` para comparativas de backends.
+- Extensión de VS Code para análisis de AST y ejecución de comandos.
+- Animación `moonwalk` y efectos adicionales en el dashboard.
+
+## [0.3.0] - 2024-05-10
+### Añadido
+- Soporte para múltiples *backends* de almacenamiento y exportación a `xlsx` y `md`.
+- Ejemplos y configuración para Streamlit y Binder.
+- Documentación inicial con Sphinx.
+
+## [0.2.0] - 2024-04-05
+### Añadido
+- Decoradores `vectorized` y `guvectorized` con *fallback* seguro.
+- Sustitución de `print` por un sistema de *logging* unificado.
+- Archivo `.env.example` para configurar el entorno.
+
+## [0.1.0] - 2024-03-01
+### Añadido
+- Lanzamiento inicial con decoradores `smooth`, `moonwalk` y `profile_it`.
+- CLI básica y arquitectura para nuevas extensiones.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Guía de Contribución
+
+¡Gracias por tu interés en mejorar Smooth Criminal!
+
+## Configuración rápida
+
+```bash
+git clone https://github.com/Alphonsus411/smooth_criminal.git
+cd smooth_criminal
+python -m venv .venv
+source .venv/bin/activate  # En Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+pip install -r docs/requirements.txt
+pip install -e .
+```
+
+## Ejecutar pruebas
+
+Antes de enviar cambios, verifica que todo funciona:
+
+```bash
+pytest
+```
+
+## Construir la documentación
+
+```bash
+sphinx-build -b html docs docs/_build/html
+```
+
+## Flujo de trabajo sugerido
+
+1. Crea una rama descriptiva a partir de `main`.
+2. Realiza tus cambios y actualiza `CHANGELOG.md`.
+3. Añade tu nombre a `CONTRIBUTORS.md` si es tu primera aportación.
+4. Ejecuta las pruebas y construye la documentación.
+5. Abre un Pull Request explicando tu contribución.
+
+¡Tu ayuda hace que el proyecto siga moviéndose al ritmo de MJ! 🕺

--- a/README.md
+++ b/README.md
@@ -313,6 +313,8 @@ exportar a `xlsx` instala `openpyxl`.
 
 Próximamente en ReadTheDocs…
 
+Consulta el [changelog](CHANGELOG.md) para conocer el historial completo de versiones.
+
 ## 📦 Empaquetado
 
 Para crear una distribución local y verificar sus metadatos:

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,0 +1,20 @@
+Contribuir
+==========
+
+Gracias por querer mejorar Smooth Criminal. Revisa `CONTRIBUTING.md <../CONTRIBUTING.md>`_ para conocer el proceso de trabajo.
+
+Contribuidores
+--------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Nombre
+     - Enlace
+     - Rol
+   * - Adolfo González
+     - https://github.com/Alphonsus411
+     - Autor principal
+   * - ChatGPT
+     - https://openai.com
+     - Documentación y soporte

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,3 +12,6 @@ Bienvenido a la documentación de Smooth Criminal
 
    usage
    api
+   contributing
+
+Para un historial detallado de versiones consulta el `Changelog <../CHANGELOG.md>`_.


### PR DESCRIPTION
## Summary
- expand CHANGELOG with history up to 0.1.0 and placeholder for next release
- add links to the changelog from README and docs index
- add contributing guide and include contributors in documentation

## Testing
- `pytest`
- `sphinx-build -b html docs docs/_build/html`


------
https://chatgpt.com/codex/tasks/task_e_68bdcf71e9fc8327b377f52b033aa498